### PR TITLE
Feature/102 add stored values to generated code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7931,7 +7931,7 @@
         "@oclif/plugin-help": "3.2.2",
         "chalk": "4.1.1",
         "cliui": "7.0.4",
-        "inquirer": "8.1.1",
+        "inquirer": "8.2.2",
         "ora": "5.4.1"
       },
       "bin": {
@@ -9306,7 +9306,7 @@
         "@oclif/plugin-help": "3.2.2",
         "chalk": "4.1.1",
         "cliui": "7.0.4",
-        "inquirer": "8.1.1",
+        "inquirer": "8.2.2",
         "ora": "5.4.1"
       },
       "dependencies": {
@@ -9342,8 +9342,7 @@
           }
         },
         "inquirer": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.1.tgz",
+          "version": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.1.tgz",
           "integrity": "sha512-hUDjc3vBkh/uk1gPfMAD/7Z188Q8cvTGl0nxwaCdwSbzFh6ZKkZh+s2ozVxbE5G9ZNRyeY0+lgbAIOUFsFf98w==",
           "requires": {
             "ansi-escapes": "^4.2.1",

--- a/packages/scafflater-cli/commands/init.js
+++ b/packages/scafflater-cli/commands/init.js
@@ -66,7 +66,8 @@ class InitCommand extends Command {
 
       const parameters = await promptMissingParameters(
         initFlags.parameters,
-        localTemplate.parameters
+        localTemplate.parameters,
+        outputConfig.globalParameters
       );
 
       await spinner("Running template initialization", async () => {

--- a/packages/scafflater-cli/commands/partial/run.js
+++ b/packages/scafflater-cli/commands/partial/run.js
@@ -16,7 +16,7 @@ const inquirer = require("inquirer");
  * Try to load cached templates and load from source if it is not available
  *
  * @param {Config} outputConfig The output config
- * @param {Scafflater} scafflater
+ * @param {Scafflater} scafflater The scafflater instance
  * @returns {Promise<LocalTemplate[]>} A list of local template
  */
 const loadTemplates = async (outputConfig, scafflater) => {

--- a/packages/scafflater-cli/commands/partial/run.js
+++ b/packages/scafflater-cli/commands/partial/run.js
@@ -181,7 +181,9 @@ class RunPartialCommand extends Command {
         runFlags.parameters,
         localPartial.parameters,
         outputConfig.globalParameters,
-        outputConfig.templates.find((rt) => rt.name === localPartial.name)
+        outputConfig.templates.find(
+          (rt) => rt.name === localPartial.templateName
+        ).templateParameters
       );
 
       await spinner("Running partial template", async () => {

--- a/packages/scafflater/errors/partial-not-found-error.js
+++ b/packages/scafflater/errors/partial-not-found-error.js
@@ -1,0 +1,13 @@
+const ScafflaterError = require("./scafflater-error");
+
+class PartialNotFoundError extends ScafflaterError {
+  constructor(templateName, partialName) {
+    super(
+      `The partial '${partialName}' was not found on template '${templateName}'`
+    );
+    this.templateName = templateName;
+    this.partialName = partialName;
+  }
+}
+
+module.exports = PartialNotFoundError;

--- a/packages/scafflater/errors/template-not-initialized-error.js
+++ b/packages/scafflater/errors/template-not-initialized-error.js
@@ -1,0 +1,10 @@
+const ScafflaterError = require("./scafflater-error");
+
+class TemplateNotInitializedError extends ScafflaterError {
+  constructor(templateName) {
+    super(`The template is Not initialized: ${templateName}`);
+    this.templateName = templateName;
+  }
+}
+
+module.exports = TemplateNotInitializedError;

--- a/packages/scafflater/scafflater-config/config.js
+++ b/packages/scafflater/scafflater-config/config.js
@@ -291,10 +291,22 @@ class Config {
       }
     }
 
+    const globalParameters = json.globalParameters
+      ? json.globalParameters.map((g) =>
+          Object.assign(new PersistedParameter(), g)
+        )
+      : [];
+
     return Promise.resolve({
       folderPath: path.dirname(filePath),
       filePath,
-      config: new Config(template, partial, templates, json.options ?? {}),
+      config: new Config(
+        template,
+        partial,
+        templates,
+        json.options ?? {},
+        globalParameters
+      ),
     });
   }
 

--- a/packages/scafflater/scafflater-config/config.test.js
+++ b/packages/scafflater/scafflater-config/config.test.js
@@ -163,6 +163,10 @@ describe("ConfigLoader", () => {
       fs.pathExists.mockResolvedValueOnce(true);
       fs.readFile.mockResolvedValueOnce(
         `{
+          "globalParameters":[{
+            "name": "global-var",
+            "value": "global-var-value"
+          }],
           "template": {
             "name": "some-type"
           },

--- a/packages/scafflater/scafflater-config/local-template.test.js
+++ b/packages/scafflater/scafflater-config/local-template.test.js
@@ -1,6 +1,7 @@
 const { LocalPartial, LocalTemplate } = require("./local-template");
 const { Config } = require("./config");
 const { ScafflaterOptions } = require("../options");
+const { ParameterConfig } = require("./parameter-config");
 
 jest.mock("fs-extra");
 jest.mock("./config");
@@ -237,6 +238,73 @@ describe("Local Template", () => {
       ).rejects.toThrowError(
         "/some-other/partial-1-1/scafflater.jsonc: partial does not belong to any template."
       );
+    });
+
+    test("getParameterConfigsByScope", () => {
+      // ARRANGE
+      const localPartial = new LocalPartial("", "the-partial", "", {}, [
+        new ParameterConfig("the-global-partial-parameter", "global"),
+        new ParameterConfig("the-template-partial-parameter", "template"),
+        new ParameterConfig("the-partial-parameter", "partial"),
+      ]);
+      const template = new LocalTemplate(
+        "",
+        "",
+        "the-template",
+        "",
+        "",
+        [localPartial],
+        {},
+        [
+          new ParameterConfig("the-parameter", "partial"),
+          new ParameterConfig("the-global-parameter", "global"),
+          new ParameterConfig("the-template-parameter", "template"),
+        ]
+      );
+
+      // ACT
+      const globals = template.getParameterConfigsByScope("global");
+      const globalsWithPartialName = template.getParameterConfigsByScope(
+        "global",
+        "the-partial"
+      );
+      const globalsWithPartialObj = template.getParameterConfigsByScope(
+        "global",
+        localPartial
+      );
+      const templaters = template.getParameterConfigsByScope("template");
+      const templateWithPartialName = template.getParameterConfigsByScope(
+        "template",
+        "the-partial"
+      );
+      const templateWithPartialObj = template.getParameterConfigsByScope(
+        "template",
+        localPartial
+      );
+
+      // ASSERT
+      expect(globals).toStrictEqual([
+        new ParameterConfig("the-global-parameter", "global"),
+      ]);
+      expect(globalsWithPartialName).toStrictEqual([
+        new ParameterConfig("the-global-parameter", "global"),
+        new ParameterConfig("the-global-partial-parameter", "global"),
+      ]);
+      expect(globalsWithPartialObj).toStrictEqual([
+        new ParameterConfig("the-global-parameter", "global"),
+        new ParameterConfig("the-global-partial-parameter", "global"),
+      ]);
+      expect(templaters).toStrictEqual([
+        new ParameterConfig("the-template-parameter", "template"),
+      ]);
+      expect(templateWithPartialName).toStrictEqual([
+        new ParameterConfig("the-template-parameter", "template"),
+        new ParameterConfig("the-template-partial-parameter", "template"),
+      ]);
+      expect(templateWithPartialObj).toStrictEqual([
+        new ParameterConfig("the-template-parameter", "template"),
+        new ParameterConfig("the-template-partial-parameter", "template"),
+      ]);
     });
   });
 });

--- a/packages/scafflater/scafflater-config/parameter-config.js
+++ b/packages/scafflater/scafflater-config/parameter-config.js
@@ -1,0 +1,39 @@
+/**
+ * @class ParameterConfig
+ * @description Describes a parameter. This object accept all parameters to get parameter from user through inquirer.
+ */
+class ParameterConfig {
+  /**
+   * Creates a parameter
+   *
+   * @param {string} name - Parameter name
+   * @param {?"partial"|"template"|"global"} scope - Parameter Scope.
+   *  For template and global scopes, the parameter will be saved to be used on future executions.
+   *  If template, the value will be loaded and available for any partial of the same template.
+   *  If global, the value will be loaded and available for any partial of any template in this folder.
+   */
+  constructor(name, scope = "partial") {
+    this.name = name;
+    this.scope = scope;
+  }
+
+  /**
+   * Parameter name
+   *
+   * @description The template name must follow the pattern [a-z-]{3,}
+   * @type {string}
+   */
+  name;
+
+  /**
+   * Parameter Scope
+   *
+   * @description For template and global scopes, the parameter will be saved to be used on future executions.
+   *  If template, the value will be loaded and available for any partial of the same template.
+   *  If global, the value will be loaded and available for any partial of any template in this folder.
+   * @type {?"partial"|"template"|"global"}
+   */
+  scope;
+}
+
+module.exports = { ParameterConfig };

--- a/packages/scafflater/scafflater-config/partial-config.js
+++ b/packages/scafflater/scafflater-config/partial-config.js
@@ -1,4 +1,5 @@
 const ScafflaterOptions = require("../options");
+const ParameterConfig = require("./parameter-config");
 
 /**
  * @class PartialConfig
@@ -12,12 +13,20 @@ class PartialConfig {
    * @param {?string} description - Partial description
    * @param {?(ScafflaterOptions|object)} options - Partial options
    * @param {?object[]} parameters - Partial parameters
+   * @param {?string[]} persistentParameters - List of parameters that should be saved to be used on future executions
    */
-  constructor(name, description = null, options = {}, parameters = []) {
+  constructor(
+    name,
+    description = null,
+    options = {},
+    parameters = [],
+    persistentParameters = []
+  ) {
     this.name = name;
     this.description = description;
     this.options = options;
     this.parameters = parameters;
+    this.persistentParameters = persistentParameters;
   }
 
   /**
@@ -46,7 +55,7 @@ class PartialConfig {
    * Parameters to generate partial.
    *
    * @description Scafflater uses Inquirer to get the parameters through scafflater-cli. The objects in this list must be assigned to inquirer question object(https://github.com/SBoudrias/Inquirer.js#questions).
-   * @type {object[]}
+   * @type {ParameterConfig[]}
    */
   parameters;
 }

--- a/packages/scafflater/scafflater-config/persisted-parameter.js
+++ b/packages/scafflater/scafflater-config/persisted-parameter.js
@@ -1,0 +1,64 @@
+/**
+ * @class PersistedParameter
+ * @description Describes a persisted parameter. It will be used to store parameter for global and template scopes
+ */
+class PersistedParameter {
+  /**
+   * Creates a parameter
+   *
+   * @param {string} name - Parameter name
+   * @param {?object} value - Parameter Value.
+   */
+  constructor(name, value = undefined) {
+    this.name = name;
+    this.value = value;
+  }
+
+  /**
+   * Parameter name
+   *
+   * @description The template name must follow the pattern [a-z-]{3,}
+   * @type {string}
+   */
+  name;
+
+  /**
+   * Parameter value
+   *
+   * @type {?object}
+   */
+  value;
+
+  /**
+   * Convert a array of PersistedParameter or ParameterConfig
+   *
+   * @param {PersistedParameter[]} parameters Array of persisted parameters
+   * @returns {object} An object of reduced parameters
+   */
+  static reduceParameters(parameters) {
+    return parameters.reduce((obj, item) => {
+      obj[item.name] = item.value;
+      return obj;
+    }, {});
+  }
+
+  /**
+   * Update the parameter value of persisted parameter in an array
+   *
+   * @param {PersistedParameter[]} parameters The persisted parameter array
+   * @param {PersistedParameter} newParameterValue The new parameter to be persisted
+   */
+  static updateParameters(parameters, newParameterValue) {
+    const index = parameters.findIndex(
+      (p) => p.name === newParameterValue.name
+    );
+
+    if (index < 0) {
+      parameters.push(newParameterValue);
+    } else {
+      parameters[index].value = newParameterValue.value;
+    }
+  }
+}
+
+module.exports = { PersistedParameter };

--- a/packages/scafflater/scafflater-config/persisted-parameter.test.js
+++ b/packages/scafflater/scafflater-config/persisted-parameter.test.js
@@ -1,0 +1,44 @@
+const { PersistedParameter } = require("./persisted-parameter");
+
+test("reduceParameters", () => {
+  // ARRANGE
+  const parameters = [
+    new PersistedParameter("par1", 1),
+    new PersistedParameter("par2", "string"),
+    new PersistedParameter("par3", true),
+  ];
+
+  // ACT
+  const result = PersistedParameter.reduceParameters(parameters);
+
+  // ASSERT
+  expect(result).toStrictEqual({
+    par1: 1,
+    par2: "string",
+    par3: true,
+  });
+});
+
+test("updateParameters", () => {
+  // ARRANGE
+  const parameters = [
+    new PersistedParameter("existing-param-1", "old-value-1"),
+    new PersistedParameter("existing-param-2", "old-value-2"),
+  ];
+  const newParameter = new PersistedParameter("new-param-3", "new-value-3");
+  const updateParameter = new PersistedParameter(
+    "existing-param-1",
+    "new-value-4"
+  );
+
+  // ACT
+  PersistedParameter.updateParameters(parameters, newParameter);
+  PersistedParameter.updateParameters(parameters, updateParameter);
+
+  // ASSERT
+  expect(parameters).toStrictEqual([
+    new PersistedParameter("existing-param-1", "new-value-4"),
+    new PersistedParameter("existing-param-2", "old-value-2"),
+    new PersistedParameter("new-param-3", "new-value-3"),
+  ]);
+});

--- a/packages/scafflater/scafflater-config/ran-template.js
+++ b/packages/scafflater/scafflater-config/ran-template.js
@@ -14,13 +14,22 @@ class RanTemplate {
    * @param {Source} source - Generated Template Source
    * @param {object[]} parameters - Template parameters
    * @param {RanPartial[]} partials - Generated partials for this template
+   * @param {?PersistedParameter[]} templateParameters List of saved template parameters to be used on future executions
    */
-  constructor(name, version, source, parameters = {}, partials = []) {
+  constructor(
+    name,
+    version,
+    source,
+    parameters = {},
+    partials = [],
+    templateParameters = []
+  ) {
     this.name = name;
     this.version = version;
     this.source = source;
     this.parameters = parameters;
     this.partials = partials;
+    this.templateParameters = templateParameters;
   }
 
   /**
@@ -59,6 +68,13 @@ class RanTemplate {
    * @type {object}
    */
   parameters;
+
+  /**
+   * Saved template parameters to be used on future executions.
+   *
+   * @type {object}
+   */
+  templateParameters;
 }
 
 module.exports = RanTemplate;

--- a/packages/scafflater/scafflater-config/ran-template.js
+++ b/packages/scafflater/scafflater-config/ran-template.js
@@ -1,5 +1,6 @@
 const Source = require("./source");
 const RanPartial = require("./ran-partial");
+const { PersistedParameter } = require("./persisted-parameter");
 
 /**
  * @class RanTemplate
@@ -14,7 +15,7 @@ class RanTemplate {
    * @param {Source} source - Generated Template Source
    * @param {object[]} parameters - Template parameters
    * @param {RanPartial[]} partials - Generated partials for this template
-   * @param {?PersistedParameter[]} templateParameters List of saved template parameters to be used on future executions
+   * @param {PersistedParameter[]} templateParameters List of saved template parameters to be used on future executions
    */
   constructor(
     name,

--- a/packages/scafflater/scafflater-config/template-config.js
+++ b/packages/scafflater/scafflater-config/template-config.js
@@ -1,4 +1,5 @@
 const ScafflaterOptions = require("../options");
+const ParameterConfig = require("./parameter-config");
 
 /**
  * @class TemplateInfo
@@ -13,19 +14,22 @@ class TemplateConfig {
    * @param {?string} description - Template description
    * @param {?(ScafflaterOptions|object)} options - Template options
    * @param {?object[]} parameters - Template parameters
+   * @param {?string[]} persistentParameters - List of parameters that should be saved to be used on future executions
    */
   constructor(
     name,
     version,
     description = null,
     options = {},
-    parameters = []
+    parameters = [],
+    persistentParameters = []
   ) {
     this.name = name;
     this.description = description;
     this.version = version;
     this.options = options;
     this.parameters = parameters;
+    this.persistentParameters = persistentParameters;
   }
 
   /**
@@ -62,7 +66,7 @@ class TemplateConfig {
    * Parameters to generate template.
    *
    * @description Scafflater uses Inquirer to get the parameters through scafflater-cli. The objects in this list must be assigned to inquirer question object(https://github.com/SBoudrias/Inquirer.js#questions).
-   * @type {object[]}
+   * @type {ParameterConfig[]}
    */
   parameters;
 }

--- a/packages/scafflater/scafflater.js
+++ b/packages/scafflater/scafflater.js
@@ -93,11 +93,6 @@ class Scafflater {
       templateVersion
     );
 
-    const maskedParameters = maskParameters(
-      parameters,
-      localTemplate.parameters
-    );
-
     const targetConfigPath = path.resolve(
       targetPath,
       ".scafflater",
@@ -110,6 +105,13 @@ class Scafflater {
     if (targetConfig.isInitialized(localTemplate.name)) {
       throw new TemplateInitialized(localTemplate.name);
     }
+
+    parameters = targetConfig.getPersistedParameters(parameters);
+
+    const maskedParameters = maskParameters(
+      parameters,
+      localTemplate.parameters
+    );
 
     const ctx = {
       template: localTemplate,
@@ -152,6 +154,7 @@ class Scafflater {
       )
     );
 
+    targetConfig.setPersistedParameters(localTemplate, parameters);
     await targetConfig.save(targetConfigPath);
   }
 
@@ -234,6 +237,11 @@ class Scafflater {
       );
     }
 
+    targetConfig.setPersistedParameters(
+      localTemplate,
+      parameters,
+      localPartial
+    );
     await targetConfig.save(targetConfigPath);
   }
 }

--- a/packages/scafflater/scafflater.test.js
+++ b/packages/scafflater/scafflater.test.js
@@ -62,6 +62,10 @@ describe("Scafflater", () => {
         isInitialized: () => {
           return false;
         },
+        getPersistedParameters: (p) => {
+          return p;
+        },
+        setPersistedParameters: jest.fn(),
       };
       Config.mockReturnValue(mockedConfig);
       Config.fromLocalPath.mockResolvedValue({
@@ -127,6 +131,10 @@ describe("Scafflater", () => {
           isInitialized: () => {
             return false;
           },
+          getPersistedParameters: (p) => {
+            return p;
+          },
+          setPersistedParameters: jest.fn(),
         },
       };
       Config.fromLocalPath.mockResolvedValue(mockedConfig);
@@ -213,6 +221,7 @@ describe("Scafflater", () => {
           ),
         ],
         save: jest.fn(),
+        setPersistedParameters: jest.fn(),
       },
     };
     const mockedLocalTemplate = new LocalTemplate(


### PR DESCRIPTION
Add scoped persisted parameters to save values globally or for template.

With this, the values are stored on scafflater config and can be used on future executions